### PR TITLE
补充可滑动子 View ID 的默认值

### DIFF
--- a/consecutivescroller/src/main/java/com/donkingliang/consecutivescroller/ConsecutiveScrollerLayout.java
+++ b/consecutivescroller/src/main/java/com/donkingliang/consecutivescroller/ConsecutiveScrollerLayout.java
@@ -2434,7 +2434,10 @@ public class ConsecutiveScrollerLayout extends ViewGroup implements ScrollingVie
          */
         public boolean isSink = false;
 
-        public int scrollChild;
+        /**
+         * 可滑动子 View 的 id
+         */
+        public int scrollChild = View.NO_ID;
 
         /**
          * 子view与父布局的对齐方式


### PR DESCRIPTION
LayoutParams 有多个构造方法, scrollChild 默认值应该是 View.NO_ID.
如果有子 View 的 id 没有赋值, 错误找到这个 View 当做 ScrollView 会导致页面无法滑动.