### PR TITLE
修复多指触控下子 View 无法拦截事件的问题

### DIFF
--- a/consecutivescroller/src/main/java/com/donkingliang/consecutivescroller/ConsecutiveScrollerLayout.java
+++ b/consecutivescroller/src/main/java/com/donkingliang/consecutivescroller/ConsecutiveScrollerLayout.java
@@ -288,6 +288,11 @@ public class ConsecutiveScrollerLayout extends ViewGroup implements ScrollingVie
      */
     private boolean isBrake = false;
 
+    /**
+     * 当前是否不允许拦截滑动事件
+     */
+    private boolean isDisallowInterceptTouchEvent = false;
+
     public ConsecutiveScrollerLayout(Context context) {
         this(context, null);
     }
@@ -598,6 +603,12 @@ public class ConsecutiveScrollerLayout extends ViewGroup implements ScrollingVie
     }
 
     @Override
+    public void requestDisallowInterceptTouchEvent(boolean disallowIntercept) {
+        super.requestDisallowInterceptTouchEvent(disallowIntercept);
+        isDisallowInterceptTouchEvent = disallowIntercept;
+    }
+
+    @Override
     public boolean dispatchTouchEvent(MotionEvent ev) {
         final int actionIndex = ev.getActionIndex();
 
@@ -654,8 +665,10 @@ public class ConsecutiveScrollerLayout extends ViewGroup implements ScrollingVie
                 mFixedYMap.put(mActivePointerId, ev.getY(actionIndex));
                 mEventY = (int) ev.getY(actionIndex);
                 mEventX = (int) ev.getX(actionIndex);
-                // 改变滑动的手指，重新询问事件拦截
-                requestDisallowInterceptTouchEvent(false);
+                if (!isDisallowInterceptTouchEvent) {
+                    // 改变滑动的手指，如果能够拦截事件, 重新询问事件拦截
+                    requestDisallowInterceptTouchEvent(false);
+                }
                 mDownLocation[0] = ScrollUtils.getRawX(this, ev, actionIndex);
                 mDownLocation[1] = ScrollUtils.getRawY(this, ev, actionIndex);
                 isTouchNotTriggerScrollStick = ScrollUtils.isTouchNotTriggerScrollStick(this, mDownLocation[0], mDownLocation[1]);


### PR DESCRIPTION
多指触控下, 子 View 希望拦截事件会调用 `requestDisallowInterceptTouchEvent` .
如果第二个 Action_Down 时父 View 强制重新请求 `requestDisallowInterceptTouchEvent`, 子 View 会收到 Cancel 导致事件被父 View 消费.

修复这个问题, 仅当前可拦截时重新请求 `requestDisallowInterceptTouchEvent`