### PR TITLE
触发checkLayoutChange时，无论scrollY是否变化，都调用scrollChange(newScrollY, oldScrollY)方法

### DIFF
--- a/consecutivescroller/src/main/java/com/donkingliang/consecutivescroller/ConsecutiveScrollerLayout.java
+++ b/consecutivescroller/src/main/java/com/donkingliang/consecutivescroller/ConsecutiveScrollerLayout.java
@@ -1720,6 +1720,10 @@ public class ConsecutiveScrollerLayout extends ViewGroup implements ScrollingVie
 
         resetChildren();
         resetSticky();
+
+        //为了解决因 某些子控件位置由滑动事件做处理，但因为调用了resetChildren()导致的位置不正确的问题
+        int scrollY = computeVerticalScrollOffset();
+        scrollChange(scrollY, scrollY);
     }
 
     /**


### PR DESCRIPTION
 解决当通过监听滑动事件来实时改变View坐标时，触发layoutChange导致view的位置不在正确位置（回到默认位置了）的问题。
 例：向上滑时，让一个ImageView以二分之一的速度向上移动，实现差速滑动效果。

加了两行代码在checkLayoutChange方法的最后，不知道会不会有其它不良影响，麻烦大大看看。